### PR TITLE
Remove Size value from WMI query

### DIFF
--- a/Marksman.cs
+++ b/Marksman.cs
@@ -319,7 +319,7 @@ namespace Marksman
             mySentry.AddQuery("WMI", "SELECT IdentifyingNumber FROM Win32_ComputerSystemProduct");
             mySentry.AddQuery("WMI", "SELECT Name FROM Win32_BIOS");
             mySentry.AddQuery("WMI", "SELECT Manufacturer,Name,MACAddress FROM Win32_NetworkAdapter WHERE NetEnabled=true AND AdapterTypeId=0 AND netConnectionStatus=2");
-            mySentry.AddQuery("WMI", "SELECT Manufacturer,Model,SerialNumber,Size FROM Win32_DiskDrive");
+            mySentry.AddQuery("WMI", "SELECT Manufacturer,Model,SerialNumber FROM Win32_DiskDrive");
             mySentry.AddQuery("WMI", "SELECT EndingAddress FROM Win32_MemoryArray");
             mySentry.AddQuery("WMI", "SELECT Name FROM Win32_DesktopMonitor");
             mySentry.AddQuery("WMI", "SELECT Manufacturer,Product,SerialNumber FROM Win32_BaseBoard");


### PR DESCRIPTION
WMI Win32_DiskDrive lists USB connected SD Card Readers which in turn have can have a null size if they don't have a SD card in them.
This causes the !String.IsNullOrWhiteSpace(property.Value.ToString()) check to crash out.
Removing this lets the application run